### PR TITLE
TempZipFile fixes

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,18 +1,14 @@
+# encoding: UTF-8
 require 'winrm-fs'
 require 'benchmark'
 
 def files
   # This is a fairly short list of small files, may also want a benchmark with larger files
-  files = `git ls-files`.lines
-  files = files.map do | file |
-    next if File.directory? file
-    # File.expand_path(file.strip, Dir.pwd)
-    file.strip
-  end.compact
+  `git ls-files`.lines.map(&:strip)
 end
 
 def create_zip(factory, file)
-  WinRM::FS::Core::TempZipFile.new(Dir.pwd, {zip_file: file, via: factory, X: true}) do | temp_zip |
+  WinRM::FS::Core::TempZipFile.new(Dir.pwd, zip_file: file, via: factory, X: true) do | temp_zip |
     temp_zip.add(*files)
   end
 end
@@ -22,4 +18,3 @@ Benchmark.bm do | benchmark |
   benchmark.report('shell') { create_zip(:shell, 'shell.zip') }
   benchmark.report('ruby') { create_zip(:rubyzip, 'ruby.zip') }
 end
-

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,0 +1,25 @@
+require 'winrm-fs'
+require 'benchmark'
+
+def files
+  # This is a fairly short list of small files, may also want a benchmark with larger files
+  files = `git ls-files`.lines
+  files = files.map do | file |
+    next if File.directory? file
+    # File.expand_path(file.strip, Dir.pwd)
+    file.strip
+  end.compact
+end
+
+def create_zip(factory, file)
+  WinRM::FS::Core::TempZipFile.new(Dir.pwd, {zip_file: file, via: factory, X: true}) do | temp_zip |
+    temp_zip.add(*files)
+  end
+end
+
+Benchmark.bm do | benchmark |
+  benchmark.report('zip cmd') { `git ls-files | zip zip_command.zip -X --names-stdin` }
+  benchmark.report('shell') { create_zip(:shell, 'shell.zip') }
+  benchmark.report('ruby') { create_zip(:rubyzip, 'ruby.zip') }
+end
+

--- a/lib/winrm-fs.rb
+++ b/lib/winrm-fs.rb
@@ -16,6 +16,7 @@
 
 require 'winrm'
 require 'logger'
+require 'pathname'
 require_relative 'winrm-fs/exceptions'
 require_relative 'winrm-fs/file_manager'
 

--- a/lib/winrm-fs/core/temp_zip_file.rb
+++ b/lib/winrm-fs/core/temp_zip_file.rb
@@ -15,71 +15,136 @@
 # limitations under the License.
 
 require 'zip'
+require 'fileutils'
 
 module WinRM
   module FS
     module Core
       # Temporary zip file on the local system
       class TempZipFile
-        attr_reader :path
+        attr_reader :zip_file, :path, :paths, :basedir, :options
+        def initialize(basedir = Dir.pwd, options = {})
+          @basedir = Pathname(basedir)
+          @options = options
+          @zip_file = options.delete(:zip_file) || Tempfile.new(['winrm_upload', '.zip'])
+          @path = Pathname(@zip_file)
+          factory = case options.delete(:via)
+          when nil, :rubyzip
+            RubyZipFactory
+          when :shell
+            ShellZipFactory
+          else
+            fail "Unknown zip factory: #{factory}"
+          end
 
-        def initialize
-          @logger = Logging.logger[self]
-          @zip_file = Tempfile.new(['winrm_upload', '.zip'])
-          @zip_file.close
-          @path = @zip_file.path
+          yield self if block_given?
+          factory.new(self).build
+          @zip_file
+        end
+
+        def paths
+          @paths ||= []
         end
 
         # Adds a file or directory to the temporary zip file
-        # @param [String] Directory or file path to add into zip
-        def add(path)
-          if File.directory?(path)
-            add_directory(path)
-          elsif File.file?(path)
-            add_file(path)
-          else
-            fail "#{path} doesn't exist"
+        # @param [String] Directory or file path relative to basedir to add into zip
+        def add(*new_paths)
+          new_paths.each do | path |
+            absolute_path = File.expand_path(path, basedir)
+            fail "#{path} must exist relative to #{basedir}" unless File.exist? absolute_path
+            paths << Pathname(absolute_path).relative_path_from(basedir)
           end
-        end
-
-        # Adds all files in the specified directory recursively into the zip file
-        # @param [String] Directory to add into zip
-        def add_directory(dir)
-          fail "#{dir} isn't a directory" unless File.directory?(dir)
-          glob = File.join(dir, '**/*')
-          Dir.glob(glob).each do |file|
-            add_file_entry(file, dir)
-          end
-        end
-
-        def add_file(file)
-          fail "#{file} isn't a file" unless File.file?(file)
-          add_file_entry(file, File.dirname(file))
         end
 
         def delete
           @zip_file.delete
         end
+      end
+
+      class ShellZipFactory
+        attr_reader :zip_definition, :basedir, :zip_file, :paths, :options
+
+        def initialize(zip_definition)
+          @zip_definition = zip_definition
+          @zip_file = zip_definition.zip_file
+          @basedir = zip_definition.basedir
+          @paths = zip_definition.paths
+          @options = zip_definition.options.map do | key, value |
+            prefix = key.length > 1 ? '--' : '-'
+            if value == true
+              "#{prefix}#{key}"
+            else
+              "#{prefix}#{key} #{value}"
+            end
+          end.join(' ')
+        end
+
+        def build
+          Dir.chdir(basedir) do
+            file_list = Tempfile.new('file_list')
+            file_list.puts paths.join("\n")
+            file_list.close
+            # We need to use the .tmp file because Tempfile creates a blank file, which zip doesn't like
+            output = `zip #{zip_definition.path}.tmp --names-stdin #{options} < #{file_list.path}`
+            fail "zip command failed: #{output}" unless $?.success?
+
+            FileUtils.mv("#{zip_definition.path}.tmp", "#{zip_definition.path}")
+          end
+        end
+      end
+
+      class RubyZipFactory
+        attr_reader :zip_definition, :basedir
+
+        def initialize(zip_definition)
+          @zip_definition = zip_definition
+          @basedir = zip_definition.basedir
+          @zip = Zip::File.open(zip_definition.path, Zip::File::CREATE)
+        end
+
+        def build
+          @zip_definition.paths.each do | path |
+            absolute_path = File.expand_path(path, basedir)
+            fail "#{path} doesn't exist" unless File.exist? absolute_path
+
+            if File.directory?(absolute_path) && zip_definition.options[:recurse_paths]
+              add_directory(path)
+            else
+              add_file(path)
+            end
+          end
+          close
+        end
+
+        def close
+          @zip.close if @zip
+        end
 
         private
 
-        def add_file_entry(file, base_dir)
-          base_dir = "#{base_dir}/" unless base_dir.end_with?('/')
-          file_entry_path = file[base_dir.length..-1]
-          write_zip_entry(file, file_entry_path)
+        # Adds all files in the specified directory recursively into the zip file
+        # @param [String] Directory to add into zip
+        def add_directory(dir)
+          glob = File.join(basedir, dir, '**/*')
+          Dir.glob(glob).each do |file|
+            add_file(file)
+          end
+        end
+
+        def add_file(file)
+          write_zip_entry(file, basedir)
         end
 
         def write_zip_entry(file, file_entry_path)
-          @logger.debug("adding zip entry: #{file_entry_path}")
-          Zip::File.open(@path, 'w') do |zipfile|
-            entry = new_zip_entry(file_entry_path)
-            zipfile.add(entry, file)
-          end
+          absolute_file = File.expand_path(file, basedir)
+          relative_file = Pathname(absolute_file).relative_path_from(basedir).to_s
+          entry = new_zip_entry(relative_file)
+          @zip.add(entry, absolute_file)
         end
 
         def new_zip_entry(file_entry_path)
           Zip::Entry.new(
-            @path,
+            @zip,
             file_entry_path,
             nil,
             nil,

--- a/lib/winrm-fs/core/upload_orchestrator.rb
+++ b/lib/winrm-fs/core/upload_orchestrator.rb
@@ -108,9 +108,11 @@ module WinRM
         end
 
         def create_temp_zip_file(local_paths)
-          temp_zip = WinRM::FS::Core::TempZipFile.new
-          local_paths.each { |p| temp_zip.add(p) }
-          temp_zip
+          WinRM::FS::Core::TempZipFile.new do |temp_zip|
+            local_paths.each do |p|
+              temp_zip.add(p)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
I've made some changes to TempZipFile to fix relative path issues in #8 and performance issues noted in #6.

I also made the class more of an abstract factory so that it could delegate to concrete factories for building zips via shell commands, rubyzip or whatever other solution might be desirable in the future.

I added a script that benchmarks the performance of `zip` vs the available TempZipFile factories.