### PR TITLE
Close handle or zip can't create (/fill) that file

### DIFF
--- a/lib/winrm-fs/core/temp_zip_file.rb
+++ b/lib/winrm-fs/core/temp_zip_file.rb
@@ -33,6 +33,7 @@ module WinRM
           @basedir = Pathname.new(basedir)
           @options = options
           @zip_file = options[:zip_file] || Tempfile.new(['winrm_upload', '.zip'])
+          @zip_file.close unless @zip_file.respond_to?('closed?') && @zip_file.closed?
           @path = Pathname.new(@zip_file)
         end
 


### PR DESCRIPTION
As described in issue #16 immediately close this handle as:
1. On Windows this file/handle is preventing RubyZip to (also) create a zip with that name
2. The (open) filehandle is not actually used anywhere

But most for the first point off course :smile: as this blocks usage on Windows.