### PR TITLE
Fix powershell streams leaking to standard error

### DIFF
--- a/lib/winrm-fs/core/command_executor.rb
+++ b/lib/winrm-fs/core/command_executor.rb
@@ -35,7 +35,7 @@ module WinRM
 
         def run_powershell(script)
           assert_shell_is_open
-          run_cmd('powershell', ['-encodedCommand', encode_script(script)])
+          run_cmd('powershell', ['-encodedCommand', encode_script(safe_script(script))])
         end
 
         def run_cmd(command, arguments = [])
@@ -62,6 +62,11 @@ module WinRM
         def encode_script(script)
           encoded_script = script.encode('UTF-16LE', 'UTF-8')
           Base64.strict_encode64(encoded_script)
+        end
+
+        # suppress the progress stream from leaking to stderr
+        def safe_script(script)
+          "$ProgressPreference='SilentlyContinue';" + script
         end
       end
     end

--- a/lib/winrm-fs/scripts/checksum.ps1.erb
+++ b/lib/winrm-fs/scripts/checksum.ps1.erb
@@ -9,5 +9,5 @@ if (Test-Path $path -PathType Leaf) {
   $md5 = $md5.Replace("-","").ToLower()
   $file.Close()
 
-  Write-Host $md5
+  Write-Output $md5
 }


### PR DESCRIPTION
Powershell has several streams. Unless, output is sent to the output stream, winrm interprets the output as error output. There are some module auto loading scenarios where powershell will send information out to the `progress` stream. This suppresses that stream all together by turning it off.

Also, the checksum script currently writes the hash using `write-host`. As of powershell v5, output sent using `write-host` directs some metadata to a new `information` stream and suffers the same problem as the `progress` stream where it causes winrm to leak to standard error. This simply replaces `write-host` with `write-output` which will be output to stdout and the console.

This fixes #18 