### PR TITLE
Fix handling of trailing slash in dir (TmpZip)

### DIFF
--- a/lib/winrm-fs/core/tmp_zip.rb
+++ b/lib/winrm-fs/core/tmp_zip.rb
@@ -117,7 +117,7 @@ module WinRM
         # @api private
         def produce_zip_entries(zos)
           entries.each do |entry|
-            entry_path = entry.sub(/#{dir}\//i, '')
+            entry_path = entry.sub(/#{Pathname.new("#{dir}.").dirname()}\//i, '')
             logger.debug "+++ Adding #{entry_path}"
             zos.put_next_entry(
               zip_entry(entry_path),


### PR DESCRIPTION
When adding files to a TmpZip using `/path/to/files/` (instead of `/path/to/files`), the current code throws errors about absolute paths in `ZipEntry` names.  This is because the regex is `/#{dir}\//i`, which translates out to `/\/path\/to\/files\/\//i`, and matches (and therefore replaces) nothing.

The intended functionality *is* to treat `/path/to/files/` differently from `/path/to/files`, but rather than the current implementation's "does not work" versus "add contents of dir", it's supposed to be "add contents of dir" versus "add contents *and* dir".  This change, which is admittedly slightly hackish, fixes that.