### PR TITLE
Add Digest option for checksum method

### DIFF
--- a/lib/winrm-fs/file_manager.rb
+++ b/lib/winrm-fs/file_manager.rb
@@ -32,9 +32,10 @@ module WinRM
       # Gets the MD5 checksum of the specified file if it exists,
       # otherwise ''
       # @param [String] The remote file path
-      def checksum(path)
-        @logger.debug("checksum: #{path}")
-        script = WinRM::FS::Scripts.render('checksum', path: path)
+      # @parms [String] The digest method
+      def checksum(path, digest = 'MD5')
+        @logger.debug("checksum with #{digest}: #{path}")
+        script = WinRM::FS::Scripts.render('checksum', path: path, digest: digest)
         @connection.shell(:powershell) { |e| e.run(script).stdout.chomp }
       end
 

--- a/lib/winrm-fs/scripts/checksum.ps1.erb
+++ b/lib/winrm-fs/scripts/checksum.ps1.erb
@@ -2,12 +2,12 @@ $p = $ExecutionContext.SessionState.Path
 $path = $p.GetUnresolvedProviderPathFromPSPath("<%= path %>")
 
 if (Test-Path $path -PathType Leaf) {
-  $cryptoProv = [System.Security.Cryptography.MD5]::Create()
+  $cryptoProv = [System.Security.Cryptography.<%= digest %>]::Create()
   $file = [System.IO.File]::Open($path,
       [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read)
-  $md5 = ([System.BitConverter]::ToString($cryptoProv.ComputeHash($file)))
-  $md5 = $md5.Replace("-","").ToLower()
+  $digest = ([System.BitConverter]::ToString($cryptoProv.ComputeHash($file)))
+  $digest = $digest.Replace("-","").ToLower()
   $file.Close()
 
-  Write-Output $md5
+  Write-Output $digest
 }


### PR DESCRIPTION
Allow to choose the digest algorithm for the checksum method.

Default is MD5 for backward compatibility.

https://msdn.microsoft.com/en-us/library/system.security.cryptography(v=vs.110).aspx