### PR TITLE
Fix issue with Pathname.glob

### DIFF
--- a/lib/winrm-fs/core/tmp_zip.rb
+++ b/lib/winrm-fs/core/tmp_zip.rb
@@ -68,7 +68,7 @@ module WinRM
         #   responds to `#debug` and `#debug?` (default `nil`)
         def initialize(dir, logger = nil)
           @logger = logger || Logging.logger[self]
-          @dir = Pathname.new(dir)
+          @dir = clean_dirname(dir)
           @zip_io = Tempfile.open(['tmpzip-', '.zip'], binmode: true)
           write_zip
           @zip_io.close
@@ -97,6 +97,17 @@ module WinRM
         # @return [IO] the Zip file IO
         # @api private
         attr_reader :zip_io
+
+        # @return [Pathname] the pathname object representing dirname that
+        # doesn't have any of those ~ in it
+        # @api private
+        def clean_dirname(dir)
+          paths = Pathname.glob(dir)
+          if paths.length != 1
+            fail "Expected Pathname.glob(dir) to return only dir, got #{paths}"
+          end
+          paths.first
+        end
 
         # @return [Array<Pathname] all recursive files under the base
         #   directory, excluding directories


### PR DESCRIPTION
Pathname.glob(dir) expands shortnames. If TmpZip was created with
a directory that did not already expand that name, then
```
entry_path = entry.sub(/#{dir}\//i, '')
```
would not correctly find the relative path from the directory for each
entry file as each entry came from a glob. This would end up creating
an empty zip file.

The other solution to the problem is to never ever use glob as it's caused many problems on Windows.

Relates to https://github.com/test-kitchen/test-kitchen/issues/1275