### PR TITLE
Use correct way to relativize paths of Zip entries

### DIFF
--- a/lib/winrm-fs/core/tmp_zip.rb
+++ b/lib/winrm-fs/core/tmp_zip.rb
@@ -125,7 +125,7 @@ module WinRM
         # @api private
         def produce_zip_entries(zos)
           entries.each do |entry|
-            entry_path = entry.sub(/#{dir}\//i, '')
+            entry_path = entry.relative_path_from(dir)
             logger.debug "+++ Adding #{entry_path}"
             zos.put_next_entry(
               zip_entry(entry_path),


### PR DESCRIPTION
Regexp method didn't work correctly whenever `dir` contained special regexp characters, e.g. `+`.

Fixes https://github.com/test-kitchen/test-kitchen/issues/1391