### PR TITLE
Missing require

### DIFF
--- a/lib/winrm-fs/core/file_transporter.rb
+++ b/lib/winrm-fs/core/file_transporter.rb
@@ -21,6 +21,7 @@ require 'digest'
 require 'securerandom'
 require 'stringio'
 
+require 'winrm/exeptions'
 require 'winrm-fs/core/tmp_zip'
 
 module WinRM

--- a/lib/winrm-fs/core/file_transporter.rb
+++ b/lib/winrm-fs/core/file_transporter.rb
@@ -21,7 +21,7 @@ require 'digest'
 require 'securerandom'
 require 'stringio'
 
-require 'winrm/exeptions'
+require 'winrm/exceptions'
 require 'winrm-fs/core/tmp_zip'
 
 module WinRM


### PR DESCRIPTION
Tried to require the file_transporter without loading any other winrm libraries and had it fail with `NameError: uninitialized constant WinRM::WinRMError`