### PR TITLE
Upload from StringIO object

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/wm6apa8ojfhfmwsf?svg=true)](https://ci.appveyor.com/project/winrb/winrm-fs)
 
 ## Uploading files
-Files may be copied from the local machine to the winrm endpoint. Individual files or directories, as well as arrays of files and directories may be specified:
+Files may be copied from the local machine to the winrm endpoint. Individual files or directories, as well as arrays of files and directories may be specified. Data from a `StringIO` object may also be uploaded to a remote file.
 ```ruby
 require 'winrm-fs'
 
@@ -16,6 +16,9 @@ file_manager.upload('file.txt', 'c:/file.txt')
 
 # upload the my_dir directory to c:/foo/my_dir
 file_manager.upload('/Users/sneal/my_dir', 'c:/foo/my_dir')
+
+# upload from an in-memory buffer
+file_manager.upload(StringIO.new('some data to upload'), 'c:/file.txt')
 
 # upload multiple directories and a file to c:\programData
 file_manager.upload([

--- a/spec/integration/file_manager_spec.rb
+++ b/spec/integration/file_manager_spec.rb
@@ -86,9 +86,25 @@ describe WinRM::FS::FileManager do
 
   context 'upload file' do
     let(:dest_file) { Pathname.new(File.join(dest_dir, File.basename(this_file))) }
+    let(:from_memory) { StringIO.new('Upload From Memory') }
 
     before(:each) do
       expect(subject.delete(dest_dir)).to be true
+    end
+
+    it 'should upload a single StringIO object to a remote file' do
+      subject.upload(from_memory, dest_file)
+      expect(subject).to have_created(dest_file).with_content(from_memory.string)
+    end
+
+    it 'should error if multiple StringIO objects passed to upload' do
+      expect { subject.upload([from_memory, from_memory], dest_file) }
+        .to raise_error(WinRM::FS::Core::UploadSourceError)
+    end
+
+    it 'should error if both a StringIO object and a file path passed to upload' do
+      expect { subject.upload([from_memory, this_file], dest_file) }
+        .to raise_error(WinRM::FS::Core::UploadSourceError)
     end
 
     it 'should upload the specified file' do


### PR DESCRIPTION
This commit adds the ability to upload a StringIO object as a source "file". This allows data from memory to be uploaded to a remote file location via winrm.