### PR TITLE
Clean up winrm connections

### DIFF
--- a/lib/winrm-fs/core/file_transporter.rb
+++ b/lib/winrm-fs/core/file_transporter.rb
@@ -115,6 +115,10 @@ module WinRM
           [total_size, files]
         end
 
+        def close
+          shell.close
+        end
+
         private
 
         # @return [String] the Array pack template for Base64 encoding a stream
@@ -179,12 +183,12 @@ module WinRM
           zip_sha1 = sha1sum(zip_io.path)
 
           hash[zip_sha1] = {
-            'src'     => dir,
+            'src' => dir,
             'src_zip' => zip_io.path.to_s,
-            'zip_io'  => zip_io,
-            'tmpzip'  => "#{TEMP_UPLOAD_DIRECTORY}\\tmpzip-#{zip_sha1}.zip",
-            'dst'     => "#{remote}\\#{File.basename(dir)}",
-            'size'    => File.size(zip_io.path)
+            'zip_io' => zip_io,
+            'tmpzip' => "#{TEMP_UPLOAD_DIRECTORY}\\tmpzip-#{zip_sha1}.zip",
+            'dst' => "#{remote}\\#{File.basename(dir)}",
+            'size' => File.size(zip_io.path)
           }
         end
 
@@ -197,9 +201,9 @@ module WinRM
         def add_file_hash!(hash, local, remote)
           logger.debug "creating hash for file #{remote}"
           hash[sha1sum(local)] = {
-            'src'   => local,
-            'dst'   => remote,
-            'size'  => local.is_a?(StringIO) ? local.size : File.size(local)
+            'src' => local,
+            'dst' => remote,
+            'size' => local.is_a?(StringIO) ? local.size : File.size(local)
           }
         end
 

--- a/lib/winrm-fs/file_manager.rb
+++ b/lib/winrm-fs/file_manager.rb
@@ -140,7 +140,7 @@ module WinRM
           begin
             file_transporter.upload(local_path, remote_path, &block)[0]
           ensure
-            file_transporter.shell.close
+            file_transporter.close
           end
         end
       end


### PR DESCRIPTION
Call close on shells so the underlying winrm connectoin is cleaned up
gracefully. Without this, wsmprovhost processes may be left active.