### PR TITLE
Reduce the number of files shipped in the gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+distro: xenial
+cache: bundler
 language: ruby
 rvm:
-  - 2.2.0
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 
 # This prevents testing branches that are created just for PRs
 branches:

--- a/lib/winrm-fs/core/file_transporter.rb
+++ b/lib/winrm-fs/core/file_transporter.rb
@@ -179,12 +179,12 @@ module WinRM
           zip_sha1 = sha1sum(zip_io.path)
 
           hash[zip_sha1] = {
-            'src'     => dir,
+            'src' => dir,
             'src_zip' => zip_io.path.to_s,
-            'zip_io'  => zip_io,
-            'tmpzip'  => "#{TEMP_UPLOAD_DIRECTORY}\\tmpzip-#{zip_sha1}.zip",
-            'dst'     => "#{remote}\\#{File.basename(dir)}",
-            'size'    => File.size(zip_io.path)
+            'zip_io' => zip_io,
+            'tmpzip' => "#{TEMP_UPLOAD_DIRECTORY}\\tmpzip-#{zip_sha1}.zip",
+            'dst' => "#{remote}\\#{File.basename(dir)}",
+            'size' => File.size(zip_io.path)
           }
         end
 
@@ -197,9 +197,9 @@ module WinRM
         def add_file_hash!(hash, local, remote)
           logger.debug "creating hash for file #{remote}"
           hash[sha1sum(local)] = {
-            'src'   => local,
-            'dst'   => remote,
-            'size'  => local.is_a?(StringIO) ? local.size : File.size(local)
+            'src' => local,
+            'dst' => remote,
+            'size' => local.is_a?(StringIO) ? local.size : File.size(local)
           }
         end
 

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rubyzip', '~> 1.1'
   s.add_runtime_dependency 'winrm', '~> 2.0'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rake', '~> 10.3'
+  s.add_development_dependency 'rake', '>= 10.3', '< 13'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.51'
 end

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     Ruby library for file system operations via Windows Remote Management
   EOF
 
-  s.files = `git ls-files`.split(/\n/)
+  s.files = Dir.glob("{bin,lib,spec}/**/*") + %w(LICENSE README.md)
   s.require_path = 'lib'
   s.rdoc_options = %w[-x test/ -x examples/]
   s.extra_rdoc_files = %w[README.md LICENSE]

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   EOF
   s.license = 'Apache-2.0'
 
-  s.files = Dir.glob('{bin,lib,spec}/**/*') + %w[LICENSE README.md]
+  s.files = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md]
   s.require_path = 'lib'
   s.rdoc_options = %w[-x test/ -x examples/]
   s.extra_rdoc_files = %w[README.md LICENSE]

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.description = <<-EOF
     Ruby library for file system operations via Windows Remote Management
   EOF
+  s.license = 'Apache-2.0'
 
   s.files = Dir.glob('{bin,lib,spec}/**/*') + %w[LICENSE README.md]
   s.require_path = 'lib'

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     Ruby library for file system operations via Windows Remote Management
   EOF
 
-  s.files = Dir.glob("{bin,lib,spec}/**/*") + %w(LICENSE README.md)
+  s.files = Dir.glob('{bin,lib,spec}/**/*') + %w[LICENSE README.md]
   s.require_path = 'lib'
   s.rdoc_options = %w[-x test/ -x examples/]
   s.extra_rdoc_files = %w[README.md LICENSE]


### PR DESCRIPTION
The gem artifact includes the full set of test files including all the
hidden files. These make perfect sense in a git repo, but aren't very
useful as installed artifacts. Removing these files reduces the number
of files on disk and speed up performance of systems with virus scanners
and such.

Here's the list of files under this change:

["bin/rwinrmcp", "lib/winrm-fs", "lib/winrm-fs/file_manager.rb", "lib/winrm-fs/core", "lib/winrm-fs/core/file_transporter.rb", "lib/winrm-fs/core/tmp_zip.rb", "lib/winrm-fs/exceptions.rb", "lib/winrm-fs/scripts", "lib/winrm-fs/scripts/download.ps1.erb", "lib/winrm-fs/scripts/scripts.rb", "lib/winrm-fs/scripts/extract_files.ps1.erb", "lib/winrm-fs/scripts/checksum.ps1.erb", "lib/winrm-fs/scripts/create_dir.ps1.erb", "lib/winrm-fs/scripts/exists.ps1.erb", "lib/winrm-fs/scripts/check_files.ps1.erb", "lib/winrm-fs/scripts/delete.ps1.erb", "lib/winrm-fs.rb", "LICENSE", "README.md"]

Signed-off-by: Tim Smith <tsmith@chef.io>