### PR TITLE
(maint) Replace erubis with erubi

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 inherit_from: .rubocop_todo.yml
-
+AllCops:
+  TargetRubyVersion: 2.2
+  
 Naming/FileName:
   Exclude:
     - 'lib/winrm-fs.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler/setup'
 require 'rspec/core/rake_task'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 

--- a/bin/rwinrmcp
+++ b/bin/rwinrmcp
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 # Copyright 2014 Shawn Neal <sneal@sneal.net>
 #

--- a/lib/winrm-fs.rb
+++ b/lib/winrm-fs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Copyright 2015 Shawn Neal <sneal@sneal.net>
 #

--- a/lib/winrm-fs/core/file_transporter.rb
+++ b/lib/winrm-fs/core/file_transporter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 #
 # Author:: Fletcher (<fnichol@nichol.ca>)
@@ -451,6 +451,7 @@ module WinRM
           read_size = ((max_encoded_write - dest.length) / 4) * 3
           chunk = 1
           bytes = 0
+          # Do not freeze this string
           buffer = ''
           shell.run(<<-PS
             $to = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("#{dest}")

--- a/lib/winrm-fs/core/file_transporter.rb
+++ b/lib/winrm-fs/core/file_transporter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Author:: Fletcher (<fnichol@nichol.ca>)
 #
@@ -31,7 +33,7 @@ module WinRM
       #
       # @author Fletcher Nichol <fnichol@nichol.ca>
       class FileTransporterFailed < ::WinRM::WinRMError; end
-      # rubocop:disable MethodLength, AbcSize, ClassLength
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/ClassLength
 
       # Exception for the case where upload source contains more than one
       # StringIO object, or a combination of file/directory paths and StringIO object
@@ -450,7 +452,7 @@ module WinRM
           chunk = 1
           bytes = 0
           buffer = ''
-          shell.run(<<-EOS
+          shell.run(<<-PS
             $to = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("#{dest}")
             $parent = Split-Path $to
             if(!(Test-path $parent)) { mkdir $parent | Out-Null }
@@ -469,7 +471,7 @@ module WinRM
             # ClearScriptBlockCache to clear it.
             $bindingFlags= [Reflection.BindingFlags] "NonPublic,Static"
             $method = [scriptblock].GetMethod("ClearScriptBlockCache", $bindingFlags)
-          EOS
+          PS
                    )
 
           while input_io.read(read_size, buffer)
@@ -486,11 +488,11 @@ module WinRM
         end
 
         def stream_command(encoded_bytes)
-          <<-EOS
+          <<-PS
             if($method) { $method.Invoke($Null, $Null) }
             $bytes=[Convert]::FromBase64String('#{encoded_bytes}')
             $fileStream.Write($bytes, 0, $bytes.length)
-          EOS
+          PS
         end
 
         # Uploads a local file.
@@ -560,7 +562,7 @@ module WinRM
           size / 3 * 4
         end
       end
-      # rubocop:enable MethodLength, AbcSize, ClassLength
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/ClassLength
     end
   end
 end

--- a/lib/winrm-fs/core/tmp_zip.rb
+++ b/lib/winrm-fs/core/tmp_zip.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Author:: Fletcher (<fnichol@nichol.ca>)
 #

--- a/lib/winrm-fs/exceptions.rb
+++ b/lib/winrm-fs/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Copyright 2015 Shawn Neal <sneal@sneal.net>
 #

--- a/lib/winrm-fs/file_manager.rb
+++ b/lib/winrm-fs/file_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Copyright 2015 Shawn Neal <sneal@sneal.net>
 #

--- a/lib/winrm-fs/scripts/scripts.rb
+++ b/lib/winrm-fs/scripts/scripts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Copyright 2015 Shawn Neal <sneal@sneal.net>
 #
@@ -19,7 +21,9 @@ module WinRM
   module FS
     # PS1 scripts
     module Scripts
+      # rubocop:disable Metrics/MethodLength
       def self.render(template, context)
+        # rubocop:enable Metrics/MethodLength
         template_path = File.expand_path(
           "#{File.dirname(__FILE__)}/#{template}.ps1.erb"
         )

--- a/spec/integration/file_manager_spec.rb
+++ b/spec/integration/file_manager_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
-# rubocop:disable BlockLength
+# rubocop:disable Metrics/BlockLength
 describe WinRM::FS::FileManager do
   let(:upload_dir) { "winrm_#{rand(2**16)}" }
   let(:dest_dir) { File.join(subject.temp_dir, upload_dir) }
@@ -300,4 +302,4 @@ describe WinRM::FS::FileManager do
     end
   end
 end
-# rubocop:enable BlockLength
+# rubocop:enable Metrics/BlockLength

--- a/spec/integration/tmp_zip_spec.rb
+++ b/spec/integration/tmp_zip_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../lib/winrm-fs/core/tmp_zip'
 
 describe WinRM::FS::Core::TmpZip do

--- a/spec/matchers.rb
+++ b/spec/matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/expectations'
 
 RSpec::Matchers.define :have_created do |remote_file|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler/setup'
 require 'winrm-fs'

--- a/spec/unit/tmp_zip_spec.rb
+++ b/spec/unit/tmp_zip_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Author:: Fletcher (<fnichol@nichol.ca>)
 #

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 
 version = File.read(File.expand_path('VERSION', __dir__)).strip
@@ -33,5 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'rubocop', '~> 0.51'
+  s.add_development_dependency 'rubocop', '~> 0.68.0'
 end

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.bindir = 'bin'
   s.executables = ['rwinrmcp']
   s.required_ruby_version = '>= 2.2.0'
-  s.add_runtime_dependency 'erubis', '~> 2.7'
+  s.add_runtime_dependency 'erubi', '~> 1.8'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'rubyzip', '~> 1.1'
   s.add_runtime_dependency 'winrm', '~> 2.0'


### PR DESCRIPTION
Port over the changes included in winrm gem to replace the deprecated erubis gem with the more light weight erubi gem. This also avoids the [cwe](https://cwe.mitre.org/data/definitions/79.html) some static analysis tools will pick up for the erubis gem.

Ported from https://github.com/WinRb/WinRM/pull/300 author: @jrafanie