### PR TITLE
Bump rubyzip dependency to 2.0 to fix CVE-2019-16892

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
   
 Naming/FileName:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ distro: xenial
 cache: bundler
 language: ruby
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 
 # This prevents testing branches that are created just for PRs
 branches:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VAGRANTFILE_API_VERSION = '2'.freeze
+VAGRANTFILE_API_VERSION = '2'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'mwrock/WindowsNano'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
   winrm_password: Pass@word1
 
   matrix:
-    - ruby_version: "22"
+    - ruby_version: "24"
       winrm_endpoint: http://localhost:5985/wsman
 
 clone_folder: c:\projects\winrm-fs

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.bindir = 'bin'
   s.executables = ['rwinrmcp']
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.4.0'
   s.add_runtime_dependency 'erubi', '~> 1.8'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'rubyzip', '~> 2.0'

--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.0'
   s.add_runtime_dependency 'erubi', '~> 1.8'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
-  s.add_runtime_dependency 'rubyzip', '~> 1.1'
+  s.add_runtime_dependency 'rubyzip', '~> 2.0'
   s.add_runtime_dependency 'winrm', '~> 2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '>= 10.3', '< 13'


### PR DESCRIPTION
For further info, see: https://nvd.nist.gov/vuln/detail/CVE-2019-16892