### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rubygems'
+require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/lib/winrm-fs.rb
+++ b/lib/winrm-fs.rb
@@ -15,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'winrm'
+require 'winrm' unless defined?(WinRM::Connection)
 require 'logger'
-require 'pathname'
+require 'pathname' unless defined?(Pathname)
 require_relative 'winrm-fs/exceptions'
 require_relative 'winrm-fs/file_manager'
 

--- a/lib/winrm-fs/core/file_transporter.rb
+++ b/lib/winrm-fs/core/file_transporter.rb
@@ -17,11 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'benchmark'
-require 'csv'
-require 'digest'
-require 'securerandom'
-require 'stringio'
+require 'benchmark' unless defined?(Benchmark)
+require 'csv' unless defined?(CSV)
+require 'digest' unless defined?(Digest)
+require 'securerandom' unless defined?(SecureRandom)
+require 'stringio' unless defined?(StringIO)
 
 require 'winrm/exceptions'
 require 'winrm-fs/core/tmp_zip'

--- a/lib/winrm-fs/core/tmp_zip.rb
+++ b/lib/winrm-fs/core/tmp_zip.rb
@@ -18,9 +18,9 @@
 # limitations under the License.
 
 require 'delegate'
-require 'pathname'
-require 'tempfile'
-require 'zip'
+require 'pathname' unless defined?(Pathname)
+require 'tempfile' unless defined?(Tempfile)
+require 'zip' unless defined?(Zip)
 
 module WinRM
   module FS

--- a/lib/winrm-fs/file_manager.rb
+++ b/lib/winrm-fs/file_manager.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'winrm'
+require 'winrm' unless defined?(WinRM::Connection)
 require_relative 'scripts/scripts'
 require_relative 'core/file_transporter'
 

--- a/spec/integration/file_manager_spec.rb
+++ b/spec/integration/file_manager_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pathname'
+require 'pathname' unless defined?(Pathname)
 
 # rubocop:disable Metrics/BlockLength
 describe WinRM::FS::FileManager do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rubygems'
+require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'
 require 'winrm-fs'
-require 'json'
+require 'json' unless defined?(JSON)
 require_relative 'matchers'
 
 # Creates a WinRM connection for integration tests


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>