### PR TITLE
Relax erubi dependency

### DIFF
--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.bindir = 'bin'
   s.executables = ['rwinrmcp']
   s.required_ruby_version = '>= 2.4.0'
-  s.add_runtime_dependency 'erubi', '~> 1.8'
+  s.add_runtime_dependency 'erubi', '>= 1.7'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'rubyzip', '~> 2.0'
   s.add_runtime_dependency 'winrm', '~> 2.0'


### PR DESCRIPTION
as strict dependencies create dependency conflicts in Fedora.

https://bugzilla.redhat.com/show_bug.cgi?id=1961480