### PR TITLE
Add csv to gemspec

### DIFF
--- a/winrm-fs.gemspec
+++ b/winrm-fs.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.bindir = 'bin'
   s.executables = ['rwinrmcp']
   s.required_ruby_version = '>= 2.5.0'
+  s.add_runtime_dependency 'csv', '~> 3.3'
   s.add_runtime_dependency 'erubi', '>= 1.7'
   s.add_runtime_dependency 'logging', ['>= 1.6.1', '< 3.0']
   s.add_runtime_dependency 'rubyzip', '~> 2.0'


### PR DESCRIPTION
Requiring csv without adding it to gemspec on Ruby 3.3.0 results in an warning:
> warning: csv was loaded from the standard library, but will no longer
> be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile
> or gemspec. Also contact author of winrm-fs-1.3.4 to add csv into its
> gemspec.