### PR TITLE
Make RuboCop lint job advisory-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    # Advisory for now: pre-existing offenses will be cleaned up in a dedicated pass.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Sets `continue-on-error: true` on the newly added lint job so lint failures never block CI. Offense cleanup will happen in a dedicated pass afterwards.