### PR TITLE
Fix lint offenses and enforce lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    # Advisory for now: pre-existing offenses will be cleaned up in a dedicated pass.
-    continue-on-error: true
+    # Required: rubocop reports zero offenses (see .rubocop.yml / .rubocop_todo.yml).
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Rubocop (1.26.1, pinned in the gemspec) reports zero offenses on the
current tree, so the lint job no longer needs to be advisory:

- Removed `continue-on-error: true` from the `lint` job in
  `.github/workflows/ci.yml` so lint is a required check.
- Updated the job comment to reflect that lint is now enforced.

No code changes were needed; the `.rubocop_todo.yml` exclusions
already cover the legacy offenses, and the gemspec's
`required_ruby_version` floor is intentionally low and unchanged.